### PR TITLE
RDKVREFPLT-3164: assembler-layer-update

### DIFF
--- a/assembler-generic.xml
+++ b/assembler-generic.xml
@@ -8,7 +8,17 @@
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_SCRIPTS"/>
     </project>
 
-    <project groups="imagebuilder" name="meta-image-builder" path="rdke/common/meta-image-support" remote="rdke" revision="404b898290b3d11eb07484d8bcc2deab1ac1aaf0">
+    <project groups="buildsupport" name="meta-rdk-auxiliary" path="rdke/common/meta-rdk-auxiliary" remote="rdke" revision="f37760a21a6a656040244fb929d84c3d56551c11">
+        <!-- RDKVREFPLT-3302: Replace with meta-aux layer matching MANIFEST_EXPORT_PATH when its is available -->
+        <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_AUXILIARY"/>
+    </project>
+
+    <project groups="stacklayering" name="meta-stack-layering-support" path="rdke/common/meta-stack-layering-support" remote="rdke" revision="refs/tags/1.3.1">
+        <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_STACK_LAYERING_SUPPORT"/>
+    </project>
+
+    <!-- RDKVREFPLT-3302: remove when meta-aux is having the complete generic bbclasses -->
+    <project groups="imagebuilder" name="meta-image-support" path="rdke/common/meta-image-support" remote="rdke" revision="refs/tags/3.0.8">
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_IMAGE_SUPPORT"/>
     </project>
 
@@ -20,11 +30,11 @@
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_PROFILE_CONFIG"/>
     </project>
 
-    <project groups="layers" name="meta-oss-reference-release" path="rdke/common/meta-oss-reference-release" remote="rdke" revision="refs/tags/3.0.3">
+    <project groups="layers" name="meta-oss-reference-release" path="rdke/common/meta-oss-reference-release" remote="rdke" revision="refs/tags/3.2.0">
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_OSS_RELEASE"/>
     </project>
 
-    <project groups="oss" name="meta-rdk-oss-reference" path="rdke/common/meta-rdk-oss-reference" remote="rdke" revision="refs/tags/3.0.3" >
+    <project groups="oss" name="meta-rdk-oss-reference" path="rdke/common/meta-rdk-oss-reference" remote="rdke" revision="refs/tags/3.2.0" >
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_COMMON_OSS_REFERENCE"/>
     </project>
 
@@ -32,19 +42,16 @@
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_OPENEMBEDDED"/>
     </project>
 
-    <project groups="oe" name="poky" path="rdke/common/poky" remote="rdke" revision="refs/tags/v1.0.5" >
+    <project groups="oe" name="poky" path="rdke/common/poky" remote="rdke" revision="refs/tags/v1.0.6" >
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_POKY"/>
     </project>
 
-    <project groups="layers" name="meta-foundation-release" path="rdke/foundation/meta-foundation-release" remote="rdke" revision="6ae33c7db14739693c924bb388b09c61eb5950a5">
-        <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_FOUNDATION_RELEASE"/>
-    </project>
-
-    <project groups="layers" name="meta-middleware-release" path="rdke/middleware/meta-middleware-release" remote="rdke" revision="feature/rpi-open-platform-integration">
+    <project groups="layers" name="meta-middleware-release" path="rdke/middleware/meta-middleware-release" remote="rdke" revision="e10100d039844a93a5cd2826ba65acf4a438f977">
+        <!-- Use SHA from feature/rpi-open-platform-integration -->
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_MW_RELEASE"/>
     </project>
 
-    <project groups="layers" name="meta-application-release-generic" path="rdke/application/meta-application-release" remote="rdkcentral" revision="refs/tags/1.0.1">
+    <project groups="layers" name="meta-application-release-generic" path="rdke/application/meta-application-release" remote="rdkcentral" revision="refs/tags/1.1.0">
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_APPLICATION_RELEASE"/>
     </project>
 

--- a/assembler-generic.xml
+++ b/assembler-generic.xml
@@ -55,7 +55,7 @@
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_APPLICATION_RELEASE"/>
     </project>
 
-    <project groups="imageassembler" name="meta-image-assembler-generic" path="rdke/image-assembler/meta-rdk-images" remote="rdkcentral" revision="refs/tags/1.0.0">
+    <project groups="imageassembler" name="meta-image-assembler-generic" path="rdke/image-assembler/meta-rdk-images" remote="rdkcentral" revision="feature/RDKVREFPLT-3164-assembler-layer-update">
         <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_RDK_IMAGES"/>
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_BBLAYERS_TEMPLATE"/>
     </project>

--- a/assembler-generic.xml
+++ b/assembler-generic.xml
@@ -55,7 +55,7 @@
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_APPLICATION_RELEASE"/>
     </project>
 
-    <project groups="imageassembler" name="meta-image-assembler-generic" path="rdke/image-assembler/meta-rdk-images" remote="rdkcentral" revision="feature/RDKVREFPLT-3164-assembler-layer-update">
+    <project groups="imageassembler" name="meta-image-assembler-generic" path="rdke/image-assembler/meta-rdk-images" remote="rdkcentral" revision="refs/tags/1.1.0">
         <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_RDK_IMAGES"/>
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_BBLAYERS_TEMPLATE"/>
     </project>

--- a/raspberrypi4-64.xml
+++ b/raspberrypi4-64.xml
@@ -5,12 +5,12 @@
     <include name="assembler-generic.xml"/>
 
     <!-- Platform specific release layers -->
-    <project groups="products" name="meta-product-raspberrypi" path="rdke/product/meta-raspberrypi4" remote="rdkcentral" revision="refs/tags/1.0.9">
+    <project groups="products" name="meta-product-raspberrypi" path="rdke/product/meta-product-raspberrypi" remote="rdkcentral" revision="refs/tags/1.1.0">
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_PRODUCT_LAYER" />
         <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_IS_OPEN_SOURCE" />
     </project>
 
-    <project groups="release" name="meta-vendor-raspberrypi-release" path="rdke/vendor/meta-vendor-release" remote="rdkcentral" revision="refs/tags/1.2.4">
+    <project groups="release" name="meta-vendor-raspberrypi-release" path="rdke/vendor/meta-vendor-release" remote="rdkcentral" revision="refs/tags/1.2.5">
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_VENDOR_RELEASE" />
     </project>
 </manifest>


### PR DESCRIPTION
This changes adds the following:
- OSS v3.2.0
- Middleware v1.9.9
- Vendor v1.2.5
- Tools update
- Remove deprecated foundation layer