### PR TITLE
RDKMVE-2589: Move RCU Keymap configuration to vendor layer

### DIFF
--- a/assembler-generic.xml
+++ b/assembler-generic.xml
@@ -33,7 +33,7 @@
     <project groups="layers" name="meta-middleware-release-rdke" path="rdke/middleware/meta-middleware-release" remote="rdkcentral" revision="refs/tags/8.6.2.0">
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_MW_RELEASE"/>
     </project>
-    <project groups="imageassembler" name="meta-image-assembler-rdke" path="rdke/image-assembler/meta-rdk-images" remote="rdkcentral" revision="refs/tags/4.1.6">
+    <project groups="imageassembler" name="meta-image-assembler-rdke" path="rdke/image-assembler/meta-rdk-images" remote="rdkcentral" revision="feature/RDKMVE-2589">
         <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_RDK_IMAGES"/>
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_BBLAYERS_TEMPLATE"/>
     </project>


### PR DESCRIPTION
Reason for change: Move RCU Keymap configuration to vendor layer
Test Procedure : Build is successful
Priority : Unprioritized
Risks : None